### PR TITLE
Adds support for variant attributes

### DIFF
--- a/macro/src/derive_macro.rs
+++ b/macro/src/derive_macro.rs
@@ -105,6 +105,8 @@ fn emit_macro(
                     @emit_enum $self { $($enum_decl)* } [
                         $($out)*
                         #(for variant in &input.variants) {
+                            //#[doc = concat!("DEBUG ATTRS: ", stringify!(#(#variant.attrs)))]
+                            #(for attrs in &variant.attrs) { #{attrs} }
                             #{ &variant.ident }
                             #(if let Named(fields) = &variant.fields) {
                                 {


### PR DESCRIPTION
Enables the 'passing through' of any attributes through to the final flattened enum

This allows the macro to handle and utilize custom attributes defined on enum variants, enhancing its flexibility and expressiveness.  In a situation like the following I needed the [data_type()] attribute passed through to each variant of the flattended enum

```rust
#[derive(FlatTarget, VesselDataType)]
pub enum Navigation {
    #[data_type(Coordinate)]
    Latitude(i32),
     ........
}

#[into_flat(VesselData)]
pub enum VesselDataComposite {
    #[flatten]
    Navigation(Navigation),
    .........
}
```